### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # oms.py
+[![Run on Repl.it](https://repl.it/badge/github/pritambuzz/oms.py)](https://repl.it/github/pritambuzz/oms.py)
 
 A micro-framework for the excellent **[Open Microservices Specification](https://openmicroservices.org)**, for suppportive code written in Python 3.6+.
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@pritampatil/omspy).